### PR TITLE
add test program for hpad + guide input, cleanup

### DIFF
--- a/dts/GEM-IO-00A0.dts
+++ b/dts/GEM-IO-00A0.dts
@@ -20,8 +20,7 @@
         "P8_46", "gpio2_7",
 
         "P9.24", "P9.26", "uart1",                    // motion control RS-422
-        "P9.21", "P9.22", "uart2",
-        "P9.11", "P9.13", "uart4";
+        "P9.21", "P9.22", "uart2";
 
 // UART 1 is connected to RA motion controller
 
@@ -69,47 +68,23 @@
         };
     };
 
-// UART 4 is connected to focus motion controller
+// 4 GPIO inputs are connected to handbox (internal pull-downs)
 
     fragment@4 {
         target = <&am33xx_pinmux>;
         __overlay__ {
-            gem_focus_uart: pinmux_gem_focus_uart {
+            gem_hbox: pinmux_gem_hbox {
                 pinctrl-single,pins = <
-                    0x074 0x06             // P9.13 mode6 output (tx)
-                    0x070 0x26             // P9.11 mode6 input (rx)
+                    0x090 0x27             // P8.7 mode7 input + p/d
+                    0x094 0x27             // P8.8 mode7 input + p/d
+                    0x09c 0x27             // P8.9 mode7 input + p/d
+                    0x098 0x27             // P8.10 mode7 input + p/d
                 >;
             };
         };
     };
 
     fragment@5 {
-        target = <&uart4>;
-        __overlay__ {
-            status = "okay";
-            pinctrl-names = "default";
-            pinctrl-0 = <&gem_focus_uart>;
-        };
-    };
-
-
-// 4 GPIO inputs are connected to handbox, with external pull-downs
-
-    fragment@6 {
-        target = <&am33xx_pinmux>;
-        __overlay__ {
-            gem_hbox: pinmux_gem_hbox {
-                pinctrl-single,pins = <
-                    0x090 0x2f             // P8.7 mode7 input
-                    0x094 0x2f             // P8.8 mode7 input
-                    0x09c 0x2f             // P8.9 mode7 input
-                    0x098 0x2f             // P8.10 mode7 input
-                >;
-            };
-        };
-    };
-
-    fragment@7 {
         target = <&ocp>;
         __overlay__ {
             gem_hbox_pinmux {
@@ -123,7 +98,7 @@
 
 // 4 GPIO inputs are connected to guide port (internal pull-ups)
 
-    fragment@8 {
+    fragment@6 {
         target = <&am33xx_pinmux>;
         __overlay__ {
             gem_guide: pinmux_gem_guide {
@@ -137,7 +112,7 @@
         };
     };
 
-    fragment@9 {
+    fragment@7 {
         target = <&ocp>;
         __overlay__ {
             gem_guide_pinmux {

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,28 +1,28 @@
 include ../Makefile.inc
 
-PROG = gem-motiond
+PROGS = gem-motiond test-hpad
 
 CFLAGS = -Wall -D_GNU_SOURCE=1 -I$(abs_topdir) \
 	 -DCONFIG_FILENAME=\"$(prefix)/etc/gem.config\"
 
-LIBS  = -L$(abs_topdir)/libutil -lutil \
-	-L$(abs_topdir)/libini -lini \
+LIBS  = -L$(abs_topdir)/libini -lini \
 	-lpthread -lev -lm -lrt
 
-OBJS = configfile.o xzmalloc.o log.o gpio.o hpad.o guide.o motion.o daemon.o
+OBJS = configfile.o xzmalloc.o log.o gpio.o hpad.o guide.o motion.o
 
-all: $(PROG)
+all: $(PROGS)
 
-$(PROG): $(OBJS)
+gem-motiond: daemon.o $(OBJS)
 	$(CC) -o $@ $^ $(LIBS)
 
-install: $(PROG)
-	cp $(PROG) $(prefix)/sbin/$(PROG)
+test-hpad: test-hpad.o $(OBJS)
+	$(CC) -o $@ $^ $(LIBS)
 
-install_cli:
+install: $(PROGS)
+	cp gem-motiond $(prefix)/sbin/gem-motiond
 
 clean:
-	rm -f *.o $(PROG)
+	rm -f *.o $(PROGS)
 
 test:
 	echo $(CFLAGS)

--- a/src/configfile.h
+++ b/src/configfile.h
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 struct config_axis {
     char *device;
     int mode;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -52,9 +52,6 @@
 
 const double sidereal_velocity = 15.0417; /* arcsec/sec */
 
-const double pub_slow = 5; /* sec */
-const double pub_fast = 0.5; /* sec */
-
 char *prog = "";
 
 struct prog_context {
@@ -79,10 +76,6 @@ void guide_cb (struct guide *g, void *arg);
 int controller_vfromarcsec (struct config_axis *axis, double arcsec_persec);
 double controller_fromarcsec (struct config_axis *axis, double arcsec);
 double controller_toarcsec (struct config_axis *axis, double steps);
-
-int controller_vfrommicrons (struct config_axis *axis, double microns_persec);
-double controller_frommicrons (struct config_axis *axis, double microns);
-double controller_tomicrons (struct config_axis *axis, double steps);
 
 #define OPTIONS "+c:hdf"
 static const struct option longopts[] = {

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -188,6 +188,13 @@ int init_stopped (struct motion *t, struct motion *d)
     return (a == 0 && b == 0);
 }
 
+/* The green LED goes off after the axes are zeroed
+ * by calling set_origin() - M1 + M2 buttons on the handpad.
+ * The LED state which lives in the motion controller
+ * persists across a daemon restart, so get the initial
+ * state of zeroed/not zeroed by reading the LED state.
+ */
+
 int init_origin (struct motion *t, struct motion *d)
 {
     uint8_t a, b;

--- a/src/guide.c
+++ b/src/guide.c
@@ -146,6 +146,8 @@ int guide_init (struct guide *g, const char *pins, double debounce,
             goto done;
         if (gpio_set_edge (p->pin, "both") < 0)
             goto done;
+        if (gpio_set_polarity (p->pin, false) < 0) // active low
+            goto done;
         if ((p->fd = gpio_open (p->pin, O_RDONLY)) < 0)
             goto done;
         p->e.data.fd = p->fd;

--- a/src/motion.h
+++ b/src/motion.h
@@ -85,10 +85,12 @@ int motion_set_origin (struct motion *m);
  *  1 in-2
  *  2 in-3
  *  3 out-1   (green LED: 0=on, 1=off)
- *  4 out-2
- *  5 out-3
+ *  4 out-2   (white LED: 0=on, 1=off)
+ *  5 out-3   (blue LED: 0=on, 1=off)
  */
-#define GREEN_LED_MASK  (8)
+#define GREEN_LED_MASK  (1<<3)
+#define WHITE_LED_MASK  (1<<4)
+#define BLUE_LED_MASK  (1<<5)
 int motion_get_port (struct motion *m, uint8_t *val);
 
 /* Write 6-bit GPIO port.

--- a/src/test-hpad.c
+++ b/src/test-hpad.c
@@ -1,0 +1,185 @@
+/*****************************************************************************\
+ *  Copyright (C) 2017 Jim Garlick
+ *  Written by Jim Garlick <garlick.jim@gmail.com>
+ *  All Rights Reserved.
+ *
+ *  This file is part of gem-controld
+ *  For details, see <https://github.com/garlick/gem-controld>
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdio.h>
+#include <getopt.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ev.h>
+
+#include "log.h"
+#include "xzmalloc.h"
+#include "configfile.h"
+#include "hpad.h"
+#include "guide.h"
+
+#define OPTIONS "+c:h"
+static const struct option longopts[] = {
+    {"config",               required_argument, 0, 'c'},
+    {"help",                 no_argument,       0, 'h'},
+    {0, 0, 0, 0},
+};
+
+void hpad_cb (struct hpad *h, void *arg);
+void guide_cb (struct guide *g, void *arg);
+
+static void usage (void)
+{
+    fprintf (stderr,
+"Usage: gem [OPTIONS]\n"
+"    -c,--config FILE    set path to config file\n"
+);
+    exit (1);
+}
+
+int main (int argc, char *argv[])
+{
+    int ch;
+    char *config_filename = NULL;
+    struct config cfg;
+    struct hpad *hpad;
+    struct guide *guide;
+    char *prog;
+    struct ev_loop *loop;
+
+    memset (&cfg, 0, sizeof (cfg));
+
+    prog = basename (argv[0]);
+    log_init (prog);
+
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'c':   /* --config FILE */
+                config_filename = xstrdup (optarg);
+                break;
+        }
+    }
+    configfile_init (config_filename, &cfg);
+
+    optind = 0;
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'c':   /* --config FILE (handled above) */
+                break;
+            case 'h':   /* --help */
+            default:
+                usage ();
+        }
+    }
+    if (optind < argc)
+        usage ();
+    if (!cfg.hpad_gpio)
+        msg_exit ("hpad_gpio was not configured");
+    if (!cfg.guide_gpio)
+        msg_exit ("guide_gpio was not configured");
+
+    if (!(loop = ev_loop_new (EVFLAG_AUTO)))
+        err_exit ("ev_loop_new");
+
+    hpad = hpad_new ();
+    if (hpad_init (hpad, cfg.hpad_gpio, cfg.hpad_debounce, hpad_cb, NULL) < 0)
+        err_exit ("hpad_init");
+    hpad_start (loop, hpad);
+    msg ("hpad configured");
+
+    guide = guide_new ();
+    if (guide_init (guide, cfg.guide_gpio, cfg.guide_debounce, guide_cb, NULL) < 0)
+        err_exit ("guide_init");
+    guide_start (loop, guide);
+    msg ("guide configured");
+
+    ev_run (loop, 0);
+
+    ev_loop_destroy (loop);
+
+    guide_stop (loop, guide);
+    guide_destroy (guide);
+
+    hpad_stop (loop, hpad);
+    hpad_destroy (hpad);
+
+    return 0;
+}
+
+void hpad_cb (struct hpad *h, void *arg)
+{
+    int val;
+
+    if ((val = hpad_read (h)) < 0) {
+        err ("hpad");
+        return;
+    }
+
+    bool fast = (val & HPAD_MASK_FAST);
+    switch (val & HPAD_MASK_KEYS) {
+        case HPAD_KEY_NONE: {
+            msg ("hpad: KEY_NONE (0x%x) fast=%s", val, fast ? "yes" : "no");
+            break;
+        }
+        case HPAD_KEY_NORTH: {
+            msg ("hpad: KEY_NORTH (0x%x) fast=%s", val, fast ? "yes" : "no");
+            break;
+        }
+        case HPAD_KEY_SOUTH: {
+            msg ("hpad: KEY_SOUTH (0x%x) fast=%s", val, fast ? "yes" : "no");
+            break;
+        }
+        case HPAD_KEY_WEST: {
+            msg ("hpad: KEY_WEST (0x%x) fast=%s", val, fast ? "yes" : "no");
+            break;
+        }
+        case HPAD_KEY_EAST: {
+            msg ("hpad: KEY_EAST (0x%x) fast=%s", val, fast ? "yes" : "no");
+            break;
+        }
+        case (HPAD_KEY_M1 | HPAD_KEY_M2): /* zero */
+            msg ("hpad: KEY_M1 and KEY_M2 (0x%x) fast=%s", val, fast ? "yes" : "no");
+            break;
+        case HPAD_KEY_M1: /* unused */
+            msg ("hpad: KEY_M1 (0x%x) fast=%s", val, fast ? "yes" : "no");
+            break;
+        case HPAD_KEY_M2: /* toggle stop */
+            msg ("hpad: KEY_M2 (0x%x) fast=%s", val, fast ? "yes" : "no");
+            break;
+    }
+}
+
+void guide_cb (struct guide *g, void *arg)
+{
+    int val;
+
+    if ((val = guide_read (g)) < 0) {
+        err ("guide");
+        return;
+    }
+    msg ("guide: (0x%x) %sRA+ %sRA- %sDEC+ %sDEC-", val,
+         (val & GUIDE_RA_PLUS) ? "*" : " ",
+         (val & GUIDE_RA_MINUS) ? "*" : " ",
+         (val & GUIDE_DEC_PLUS) ? "*" : " ",
+         (val & GUIDE_DEC_MINUS) ? "*" : " ");
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
Due to a short on the BB cape prototype when pressing one of the hpad buttons, I did some hardware rework of the board and then thought it would be good to have a standalone test program that checks buttons on the hpad and also the guide port.

Part of the rework was to remove unnecessary external pull-downs on the hpad inputs.  Altered the device tree overlay to enable the internal pull-downs.

Removed some dead code.