### PR TITLE
rewrite motion with reactive model

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -307,7 +307,7 @@ int lookup_rate (struct config_axis *axis, int rate,
  * handle this, even if direction is reversed.  The "key release" cancels
  * this and any other slew in progress.  The axes are independent.
  * It is possible to configure slew rates that will result in a controller
- * error;  motion_set_velocity() will return -1 with errno == EINVAL in
+ * error;  motion_move_constant() will return -1 with errno == EINVAL in
  * that case and the slew will fail.
  */
 void slew_update (struct prog_context *ctx, int newmask, int rate)
@@ -320,16 +320,16 @@ void slew_update (struct prog_context *ctx, int newmask, int rate)
     if ((newmask & SLEW_RA_PLUS) || (newmask & SLEW_RA_MINUS)) {
         int cv = lookup_rate (&ctx->opt.t, rate, (newmask & SLEW_RA_MINUS),
                               ctx->t_tracking, ctx->west);
-        if (motion_set_velocity (ctx->t, cv) < 0)
-            err ("t: set velocity %d", cv);
+        if (motion_move_constant (ctx->t, cv) < 0)
+            err ("t: move at v=%d", cv);
     }
     else {
         if ((ctx->slew & SLEW_RA_PLUS) || (ctx->slew & SLEW_RA_MINUS)) {
             if (ctx->t_tracking) {
                 int cv = lookup_rate (&ctx->opt.t, 0, false,
                                      ctx->t_tracking, ctx->west);
-                if (motion_set_velocity (ctx->t, cv) < 0)
-                    err ("t: set velocity %d", cv);
+                if (motion_move_constant (ctx->t, cv) < 0)
+                    err ("t: move at v=%d", cv);
             }
             else {
                 if (motion_soft_stop (ctx->t) < 0)
@@ -340,8 +340,8 @@ void slew_update (struct prog_context *ctx, int newmask, int rate)
     if ((newmask & SLEW_DEC_PLUS) || (newmask & SLEW_DEC_MINUS)) {
         int cv = lookup_rate (&ctx->opt.d, rate, (newmask & SLEW_DEC_MINUS),
                               false, false);
-        if (motion_set_velocity (ctx->d, cv) < 0)
-            err ("d: set velocity %d", cv);
+        if (motion_move_constant (ctx->d, cv) < 0)
+            err ("d: move at v=%d", cv);
     }
     else {
         if ((ctx->slew & SLEW_DEC_PLUS) || (ctx->slew & SLEW_DEC_MINUS)) {
@@ -384,8 +384,8 @@ void hpad_cb (struct hpad *h, void *arg)
             if (!(ctx->slew & SLEW_RA_PLUS) && !(ctx->slew & SLEW_RA_MINUS)) {
                 int cv = lookup_rate (&ctx->opt.t, SLEW_RATE_NONE, false,
                                       true, ctx->west);
-                if (motion_set_velocity (ctx->t, cv) < 0)
-                    err ("t: set velocity %d", cv);
+                if (motion_move_constant (ctx->t, cv) < 0)
+                    err ("t: move at v=%d", cv);
             }
             ctx->t_tracking = true;
         }

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -473,9 +473,9 @@ void lx200_goto_cb (struct lx200 *lx, void *arg)
     t = t_degrees/360.0 * ctx->opt.t.steps;
     d = d_degrees/360.0 * ctx->opt.d.steps;
 
-    if (motion_set_position (ctx->t, ctx->west ? t : -1*t) < 0)
+    if (motion_goto_absolute (ctx->t, ctx->west ? t : -1*t) < 0)
         err ("t: set position");
-    if (motion_set_position (ctx->d, d) < 0)
+    if (motion_goto_absolute (ctx->d, d) < 0)
         err ("t: set position");
 }
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -246,8 +246,8 @@ struct motion *init_axis (struct config_axis *a, const char *name, int flags)
             err_exit ("%s: set initial velocity", name);
         if (motion_set_final_velocity (m, a->finalv) < 0)
             err_exit ("%s: set final velocity", name);
-        if (motion_set_port (m, GREEN_LED_MASK | WHITE_LED_MASK
-                                               | BLUE_LED_MASK) < 0)
+        if (motion_set_io (m, MOTION_IO_OUTPUT1 | MOTION_IO_OUTPUT2
+                                                | MOTION_IO_OUTPUT3) < 0)
             err_exit ("%s: motion set port", name);
     }
     return m;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -67,13 +67,15 @@ struct motion *init_axis (struct config_axis *a, const char *name, int flags);
 void hpad_cb (struct hpad *h, void *arg);
 void guide_cb (struct guide *g, void *arg);
 void bbox_cb (struct bbox *bb, void *arg);
+void motion_cb (struct motion *m, void *arg);
 void lx200_pos_cb (struct lx200 *lx, void *arg);
 void lx200_slew_cb (struct lx200 *lx, void *arg);
 void lx200_goto_cb (struct lx200 *lx, void *arg);
+void lx200_stop_cb (struct lx200 *lx, void *arg);
 
 int controller_velocity (struct config_axis *axis, double degrees_persec);
 
-#define OPTIONS "+c:hMBLHGwf"
+#define OPTIONS "+c:hMBLHGw"
 static const struct option longopts[] = {
     {"config",               required_argument, 0, 'c'},
     {"help",                 no_argument,       0, 'h'},
@@ -83,7 +85,6 @@ static const struct option longopts[] = {
     {"debug-hpad",           no_argument,       0, 'H'},
     {"debug-guide",          no_argument,       0, 'G'},
     {"west",                 no_argument,       0, 'w'},
-    {"force",                no_argument,       0, 'f'},
     {0, 0, 0, 0},
 };
 
@@ -98,7 +99,6 @@ static void usage (void)
 "    -L,--debug-lx200    emit lx200 protocol to stderr\n"
 "    -H,--debug-hpad     emit hpad events to stderr\n"
 "    -G,--debug-guide    emit guide pulse events to stderr\n"
-"    -f,--force          force motion controller reset (must reset origin)\n"
 );
     exit (1);
 }
@@ -139,9 +139,6 @@ int main (int argc, char *argv[])
             case 'G':   /* --debug-guide */
                 guide_flags |= GUIDE_DEBUG;
                 break;
-            case 'f':   /* --force */
-                motion_flags |= MOTION_RESET;
-                break;
             case 'w':   /* --west */
                 ctx.west = true;
                 break;
@@ -162,18 +159,12 @@ int main (int argc, char *argv[])
         err_exit ("ev_loop_new");
 
     ctx.t = init_axis (&ctx.opt.t, "t", motion_flags);
-    ctx.d = init_axis (&ctx.opt.d, "d", motion_flags);
+    motion_set_cb (ctx.t, motion_cb, &ctx);
+    motion_start (ctx.loop, ctx.t);
 
-    /* Initialize t_tracking state from actual state of t motion controller.
-     * If the daemon was restarted, we should retain this state.
-     */
-    uint8_t t_status;
-    if (motion_get_status (ctx.t, &t_status) < 0)
-        err_exit ("motion_get_status t");
-    if (t_status != 0)
-        ctx.t_tracking = true;
-    msg ("tracking in RA is %s - press handpad M2 button to toggle",
-          ctx.t_tracking ? "enabled" : "disabled");
+    ctx.d = init_axis (&ctx.opt.d, "d", motion_flags);
+    motion_set_cb (ctx.d, motion_cb, &ctx);
+    motion_start (ctx.loop, ctx.d);
 
     ctx.hpad = hpad_new ();
     if (hpad_init (ctx.hpad, ctx.opt.hpad_gpio, ctx.opt.hpad_debounce,
@@ -199,6 +190,7 @@ int main (int argc, char *argv[])
     lx200_set_position_cb (ctx.lx200, lx200_pos_cb, &ctx);
     lx200_set_slew_cb (ctx.lx200, lx200_slew_cb, &ctx);
     lx200_set_goto_cb (ctx.lx200, lx200_goto_cb, &ctx);
+    lx200_set_stop_cb (ctx.lx200, lx200_stop_cb, &ctx);
     lx200_start (ctx.loop, ctx.lx200);
 
     ev_run (ctx.loop, 0);
@@ -224,32 +216,27 @@ int main (int argc, char *argv[])
 
 struct motion *init_axis (struct config_axis *a, const char *name, int flags)
 {
+    struct motion_config cfg = {
+        .resolution = a->resolution,
+        .ihold      = a->ihold,
+        .irun       = a->irun,
+        .mode       = a->mode,
+        .accel      = a->accel,
+        .decel      = a->decel,
+        .initv      = a->initv,
+        .finalv     = a->finalv,
+    };
     struct motion *m;
-    bool coldstart;
 
     if (!a->device)
         msg_exit ("%s: no serial device configured", name);
     if (!(m = motion_new (name)))
         err_exit ("%s: motion_create", name);
-    if (motion_init (m, a->device, flags, &coldstart) < 0)
+    if (motion_init (m, a->device, &cfg, flags) < 0)
         err_exit ("%s: motion_init %s", name, a->device);
-    if (coldstart) {
-        if (motion_set_current (m, a->ihold, a->irun) < 0)
-            err_exit ("%s: set current", name);
-        if (motion_set_mode (m, a->mode) < 0)
-            err_exit ("%s: set mode", name);
-        if (motion_set_resolution (m, a->resolution) < 0)
-            err_exit ("%s: set resolution", name);
-        if (motion_set_acceleration (m, a->accel, a->decel) < 0)
-            err_exit ("%s: set acceleration", name);
-        if (motion_set_initial_velocity (m, a->initv) < 0)
-            err_exit ("%s: set initial velocity", name);
-        if (motion_set_final_velocity (m, a->finalv) < 0)
-            err_exit ("%s: set final velocity", name);
-        if (motion_set_io (m, MOTION_IO_OUTPUT1 | MOTION_IO_OUTPUT2
-                                                | MOTION_IO_OUTPUT3) < 0)
-            err_exit ("%s: motion set port", name);
-    }
+    if (motion_set_io (m, MOTION_IO_OUTPUT1 | MOTION_IO_OUTPUT2
+                                            | MOTION_IO_OUTPUT3) < 0)
+        err_exit ("%s: motion set port", name);
     return m;
 }
 
@@ -362,10 +349,10 @@ void hpad_cb (struct hpad *h, void *arg)
     /* M1 - emergency stop
      */
     if ((ctrl & HPAD_CONTROL_M1)) {
-        if (motion_soft_stop (ctx->t) < 0)
-            err ("t: stop");
-        if (motion_soft_stop (ctx->d) < 0)
-            err ("d: stop");
+        if (motion_abort (ctx->t) < 0)
+            err ("t: motion_abort");
+        if (motion_abort (ctx->d) < 0)
+            err ("d: motion_abort");
         ctx->t_tracking = false;
         ctx->slew = 0;
         return;
@@ -473,10 +460,41 @@ void lx200_goto_cb (struct lx200 *lx, void *arg)
     t = t_degrees/360.0 * ctx->opt.t.steps;
     d = d_degrees/360.0 * ctx->opt.d.steps;
 
+    msg ("t,d: goto begin");
     if (motion_goto_absolute (ctx->t, ctx->west ? t : -1*t) < 0)
         err ("t: set position");
     if (motion_goto_absolute (ctx->d, d) < 0)
-        err ("t: set position");
+        err ("d: set position");
+}
+
+/* LX200 protocol wants to stop all motion (abort a goto).
+ */
+void lx200_stop_cb (struct lx200 *lx, void *arg)
+{
+    struct prog_context *ctx = arg;
+
+    if (motion_soft_stop (ctx->t) < 0)
+        err ("t: soft stop");
+    if (motion_soft_stop (ctx->d) < 0)
+        err ("d: soft stop");
+}
+
+/* Motion axis informs us that goto has completed.
+ * Goto cancels the constant velocity motion of RA tracking,
+ * so resume it here if enabled.
+ * FIXME: need to account for lost tracking for the duration of the goto.
+ */
+void motion_cb (struct motion *m, void *arg)
+{
+    struct prog_context *ctx = arg;
+
+    msg ("%s: goto end", motion_get_name (m));
+    if (ctx->t_tracking && m == ctx->t) {
+        int cv = lookup_rate (&ctx->opt.t, SLEW_RATE_NONE, false,
+                              true, ctx->west);
+        if (motion_move_constant (ctx->t, cv) < 0)
+            err ("t: move at v=%d", cv);
+    }
 }
 
 /*

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -216,10 +216,8 @@ int main (int argc, char *argv[])
     hpad_stop (ctx.loop, ctx.hpad);
     hpad_destroy (ctx.hpad);
 
-    if (ctx.d)
-        motion_fini (ctx.d);
-    if (ctx.t)
-        motion_fini (ctx.t);
+    motion_destroy (ctx.d);
+    motion_destroy (ctx.t);
 
     return 0;
 }
@@ -231,8 +229,10 @@ struct motion *init_axis (struct config_axis *a, const char *name, int flags)
 
     if (!a->device)
         msg_exit ("%s: no serial device configured", name);
-    if (!(m = motion_init (a->device, name, flags, &coldstart)))
-        err_exit ("%s: init %s", name, a->device);
+    if (!(m = motion_new (name)))
+        err_exit ("%s: motion_create", name);
+    if (motion_init (m, a->device, flags, &coldstart) < 0)
+        err_exit ("%s: motion_init %s", name, a->device);
     if (coldstart) {
         if (motion_set_current (m, a->ihold, a->irun) < 0)
             err_exit ("%s: set current", name);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -332,7 +332,7 @@ void slew_update (struct prog_context *ctx, int newmask, int rate)
                     err ("t: set velocity %d", cv);
             }
             else {
-                if (motion_stop (ctx->t) < 0)
+                if (motion_soft_stop (ctx->t) < 0)
                     err ("t: stop");
             }
         }
@@ -345,7 +345,7 @@ void slew_update (struct prog_context *ctx, int newmask, int rate)
     }
     else {
         if ((ctx->slew & SLEW_DEC_PLUS) || (ctx->slew & SLEW_DEC_MINUS)) {
-            if (motion_stop (ctx->d) < 0)
+            if (motion_soft_stop (ctx->d) < 0)
                 err ("d: stop");
         }
     }
@@ -362,9 +362,9 @@ void hpad_cb (struct hpad *h, void *arg)
     /* M1 - emergency stop
      */
     if ((ctrl & HPAD_CONTROL_M1)) {
-        if (motion_stop (ctx->t) < 0)
+        if (motion_soft_stop (ctx->t) < 0)
             err ("t: stop");
-        if (motion_stop (ctx->d) < 0)
+        if (motion_soft_stop (ctx->d) < 0)
             err ("d: stop");
         ctx->t_tracking = false;
         ctx->slew = 0;
@@ -375,7 +375,7 @@ void hpad_cb (struct hpad *h, void *arg)
     if ((ctrl & HPAD_CONTROL_M2)) {
         if (ctx->t_tracking) {
             if (!(ctx->slew & SLEW_RA_PLUS) && !(ctx->slew & SLEW_RA_MINUS)) {
-                if (motion_stop (ctx->t) < 0)
+                if (motion_soft_stop (ctx->t) < 0)
                     err ("t: stop");
             }
             ctx->t_tracking = false;

--- a/src/hpad.c
+++ b/src/hpad.c
@@ -155,10 +155,16 @@ int hpad_get_slew_rate (struct hpad *h)
 {
     int result;
 
-    if ((h->val & HPAD_KEY_FAST))
+    if ((h->val & HPAD_KEY_FAST)) {
+        if ((h->flags & HPAD_DEBUG))
+            msg ("hpad: rate=fast");
         result = SLEW_RATE_FAST;
-    else
+    }
+    else {
+        if ((h->flags & HPAD_DEBUG))
+            msg ("hpad: rate=slow");
         result = SLEW_RATE_MEDIUM;
+    }
     return result;
 }
 
@@ -168,11 +174,20 @@ int hpad_get_control (struct hpad *h)
 
     switch ((h->val & 0x7)) {
         case (HPAD_KEY_M1 | HPAD_KEY_M2):
+            if ((h->flags & HPAD_DEBUG))
+                msg ("hpad: control=M1+M2");
             result = HPAD_CONTROL_M1 | HPAD_CONTROL_M2;
+            break;
         case HPAD_KEY_M1:
+            if ((h->flags & HPAD_DEBUG))
+                msg ("hpad: control=M1");
             result = HPAD_CONTROL_M1;
+            break;
         case HPAD_KEY_M2:
+            if ((h->flags & HPAD_DEBUG))
+                msg ("hpad: control=M2");
             result = HPAD_CONTROL_M2;
+            break;
     }
     return result;
 }

--- a/src/lx200.h
+++ b/src/lx200.h
@@ -32,6 +32,10 @@ void lx200_set_slew_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
  */
 void lx200_set_goto_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
 
+/* Register callback that is triggered when protocol wants to stop all motion.
+ */
+void lx200_set_stop_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
+
 /* Set t,d position in degrees.
  */
 void lx200_set_position (struct lx200 *lx, double t, double d);

--- a/src/lx200.h
+++ b/src/lx200.h
@@ -8,7 +8,7 @@ enum {
 };
 
 struct lx200;
-typedef void (*lx200_cb_t)(struct lx200 *lx, void *arg);
+typedef void (*lx200_cb_f)(struct lx200 *lx, void *arg);
 
 struct lx200 *lx200_new (void);
 void lx200_destroy (struct lx200 *lx);
@@ -18,19 +18,19 @@ int lx200_init (struct lx200 *lx, int port, int flags);
 /* Register callback that is triggered when the protocol needs
  * a position update.  Callback should call lx200_set_position().
  */
-void lx200_set_position_cb  (struct lx200 *lx, lx200_cb_t cb, void *arg);
+void lx200_set_position_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
 
 /* Register callback that is triggered when slew (virtual) buttons
  * are pressed or released.  Callback should call lx200_get_slew()
  * and then make appropriate movement.
  */
-void lx200_set_slew_cb  (struct lx200 *lx, lx200_cb_t cb, void *arg);
+void lx200_set_slew_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
 
 /* Register callback that is triggered when protocol wants to goto
  * the target object.  Callback should call lx200_get_target ()
  * and then move to those coordinates.
  */
-void lx200_set_goto_cb  (struct lx200 *lx, lx200_cb_t cb, void *arg);
+void lx200_set_goto_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
 
 /* Set t,d position in degrees.
  */

--- a/src/motion.c
+++ b/src/motion.c
@@ -348,7 +348,7 @@ int motion_get_position (struct motion *m, double *position)
     return 0;
 }
 
-int motion_set_position (struct motion *m, double position)
+int motion_goto_absolute (struct motion *m, double position)
 {
     if (fabs (position) > 8388607.9) {
         errno = EINVAL;
@@ -372,7 +372,7 @@ int motion_get_status (struct motion *m, uint8_t *status)
     return 0;
 }
 
-int motion_set_index (struct motion *m, double offset)
+int motion_goto_relative (struct motion *m, double offset)
 {
     if (fabs (offset) < 0.01 || fabs (offset) > 8388607.99) {
         errno = EINVAL;

--- a/src/motion.c
+++ b/src/motion.c
@@ -391,16 +391,12 @@ int motion_stop (struct motion *m)
     return mcmd (m, "@");
 }
 
-int motion_set_port (struct motion *m, uint8_t val)
+int motion_set_io (struct motion *m, uint8_t val)
 {
-    if (val & 0b11000111) {
-        errno = EINVAL;
-        return -1;
-    }
     return mcmd (m, "A%d", val);
 }
 
-int motion_get_port (struct motion *m, uint8_t *val)
+int motion_get_io (struct motion *m, uint8_t *val)
 {
     char buf[max_cmdline];
     int v;

--- a/src/motion.c
+++ b/src/motion.c
@@ -324,7 +324,7 @@ int motion_set_final_velocity (struct motion *m, int velocity)
     return mcmd (m, "V%d", velocity);
 }
 
-int motion_set_velocity (struct motion *m, int velocity)
+int motion_move_constant (struct motion *m, int velocity)
 {
     if (velocity != 0 && (abs (velocity) < 20  || abs (velocity) > 20000)) {
         errno = EINVAL;

--- a/src/motion.c
+++ b/src/motion.c
@@ -386,7 +386,7 @@ int motion_set_origin (struct motion *m)
     return mcmd (m, "O");
 }
 
-int motion_stop (struct motion *m)
+int motion_soft_stop (struct motion *m)
 {
     return mcmd (m, "@");
 }

--- a/src/motion.c
+++ b/src/motion.c
@@ -22,13 +22,35 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-/* motion.c - communicate with Intelligent Motion Devices IM483I indexer */
+/* motion.c - communicate with IMS im483i indexer */
+
+/* N.B. The im483i can only handle one command a time.  It is "busy" if a
+ * command has been sent, but a result has not yet been received.
+ *
+ * Commands are terminated with \r.
+ * Results are terminated with \r\n.
+ *
+ * Communication is assumed to be in single mode, not party line.
+ *
+ * The im483ie (encoder version) should work but no support for encoder
+ * based operations is included.
+ *
+ * The Z1 mode, which causes position updates terminated with \r to be sent
+ * continuously until the next command, is not used here, and is not handled
+ * by the command/result framing code.
+ *
+ * Ref: High Performance Microstepper Driver & Indexer Software Reference
+ * Manual, Intelligent Motion Systems, Inc.
+ * https://motion.schneider-electric.com/downloads/manuals/imx_software.pdf
+ * http://lennon.astro.northwestern.edu/Computers/IMSmanual.html
+ */
 
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <termios.h>
 #include <errno.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -36,18 +58,40 @@
 #include <assert.h>
 #include <stdarg.h>
 #include <math.h>
+#include <ev.h>
 
+#include "log.h"
 #include "motion.h"
+
 
 struct motion {
     int fd;
     char *name;
     int flags;
+    ev_io io_w;
+    ev_timer status_poll_w;
+    ev_timer timeout_w;
+    bool timeout;
+    struct ev_loop *main_loop;
+    struct ev_loop *tmp_loop;
+    char inbuf[1024];
+    int inbuf_len;
+    bool busy;
+    motion_cb_f cb;
+    void *cb_arg;
 };
 
-const int max_cmdline = 80;
+static const double status_poll_sec = 0.3;  // poll period during goto
 
-/* Translate funny characters into readable debug output.
+static const double timeout_sec = 5.;   // waiting for result - give up
+static const double warn_sec = 1.;      // waiting for result - warn
+
+static int result_recv (struct motion *m, char *buf, int len);
+static void result_clear (struct motion *m);
+static int serial_send (int fd, const char *s);
+
+
+/* Translate unprintable characters into readable debug output.
  * Caller must free resulting string.
  */
 static char *toliteral (const char *s)
@@ -61,6 +105,8 @@ static char *toliteral (const char *s)
         while (*p) {
             if (*p == '\r')
                 sprintf (buf + strlen (buf), "\\r");
+            else if (*p == '\n')
+                sprintf (buf + strlen (buf), "\\n");
             else if (*p < ' ' || *p > '~')
                 sprintf (buf + strlen (buf), "\\%.3o", *p);
             else
@@ -71,137 +117,195 @@ static char *toliteral (const char *s)
     return buf;
 }
 
-static int dgetc (int fd)
-{
-    uint8_t c;
-    int n = read (fd, &c, 1);
-    if (n == 0)
-        errno = ETIMEDOUT;
-    if (n <= 0)
-        return -1;
-    return c;
-}
-
-/* Read a line ending in \r\n from 'fd' and return it, without the \r\n,
- * using buf[size] as storage.  If there is a read error or buf overflow,
- * return NULL.
+/* If busy, wait for result, then clear result buffer.
+ * Send string to serial port with \r terminator, then set busy flag.
  */
-static char *mgets (struct motion *m, char *buf, int size)
+static int command_send (struct motion *m, const char *s)
 {
-    int c;
-    int i = 0;
-    int term = 0;
+    char buf[80];
 
-    assert (size > 1);
-    memset (buf, 0, size);
-    while (term < 2 && i < size - 2 && (c = dgetc (m->fd)) != -1) {
-        if (c == '\r' || c == '\n')
-            term++;
-        else {
-            term = 0;
-            buf[i++] = c;
-        }
+    if (m->busy) {
+        if (result_recv (m, NULL, 0) < 0)
+            return -1;
     }
-    if (term != 2)
-        return NULL;
-    buf[i] = '\0';
+    result_clear (m);
+
+    if (snprintf (buf, sizeof (buf), "%s\r", s) >= sizeof (buf)) {
+        errno = EINVAL;
+        return -1;
+    }
     if (m->flags & MOTION_DEBUG) {
         char *cpy = toliteral (buf);
-        fprintf (stderr, "%s<'%s'\n", m->name, cpy);
-        free (cpy);
-    }
-    return buf;
-}
-
-static int mputs (struct motion *m, const char *s)
-{
-    if (m->flags & MOTION_DEBUG) {
-        char *cpy = toliteral (s);
         fprintf (stderr, "%s>'%s'\n", m->name, cpy);
         free (cpy);
     }
-    return dprintf (m->fd, "%s", s);
+    if (serial_send (m->fd, buf) < 0)
+        return -1;
+
+    m->busy = true;
+
+    return 0;
 }
 
-static int mprintf (struct motion *m, const char *fmt, ...)
+/* printf-style wrapper for command_send().
+ */
+static int command_sendf (struct motion *m, const char *fmt, ...)
 {
     va_list ap;
     char *s = NULL;
     int rc;
 
     va_start (ap, fmt);
-    if (vasprintf (&s, fmt, ap) < 0)
-        return -1;
+    rc = vasprintf (&s, fmt, ap);
     va_end (ap);
-    rc = mputs (m, s);
+    if (rc < 0)
+        goto done;
+    rc = command_send (m, s);
+done:
     free (s);
     return rc;
 }
 
-/* Send a \r, receive a #.
- */
-static int mping (struct motion *m, int count)
+/* helper for result_clear() and result_recv() */
+static int result_consume (struct motion *m, char *buf, int len)
 {
-    int i;
-    char buf[max_cmdline];
-    int rc = -1;
+    char *p;
+    int used;
 
-    for (i = 0; i < count; i++) {
-        if (mputs (m, "\r") < 0 || !mgets (m, buf, sizeof (buf)))
-            goto done;
-        if (strcmp (buf, "#") != 0) {
-            errno = EPROTO;
-            goto done;
+    if (!(p = strstr (m->inbuf, "\r\n")))
+        return -1;
+    assert (p != NULL);
+    *p = '\0';
+
+    if ((m->flags & MOTION_DEBUG)) {
+        char *cpy = toliteral (m->inbuf);
+        fprintf (stderr, "%s<'%s\\r\\n'\n", m->name, cpy);
+        free (cpy);
+    }
+
+    if (buf)
+        snprintf (buf, len, "%s", m->inbuf);
+
+    used = strlen (m->inbuf) + 2;
+    memmove (m->inbuf, m->inbuf + used, m->inbuf_len - used);
+    m->inbuf_len -= used;
+    m->inbuf[m->inbuf_len] = '\0';
+    m->busy = false;
+    return 0;
+}
+
+/* Clear the result buffer.
+ */
+static void result_clear (struct motion *m)
+{
+    while (result_consume (m, NULL, 0) == 0)
+        ;
+}
+
+static void timeout_cb (struct ev_loop *loop, ev_timer *w, int revents)
+{
+    struct motion *m = (struct motion *)((char *)w
+                        - offsetof (struct motion, timeout_w));
+
+    ev_break (loop, EVBREAK_ALL);
+    m->timeout = true;
+}
+
+/* Block until one or more results are received and stored in the inbuf,
+ * then unwrap one and return it in 'buf' without the \r\n termination.
+ */
+static int result_recv (struct motion *m, char *buf, int len)
+{
+    double t0, wait_time = 0.;
+
+    if (!strstr (m->inbuf, "\r\n")) {
+        /* move io watcher to temporary loop */
+        if (m->main_loop)
+            ev_io_stop (m->main_loop, &m->io_w);
+        ev_io_start (m->tmp_loop, &m->io_w);
+
+        m->timeout = false;
+        t0 = ev_now (m->tmp_loop);
+        ev_timer_set (&m->timeout_w, timeout_sec, 0.);
+        ev_timer_start (m->tmp_loop, &m->timeout_w);
+        while (!strstr (m->inbuf, "\r\n")) {
+            if (ev_run (m->tmp_loop, EVRUN_ONCE) < 0 || m->timeout)
+                break;
+        }
+        ev_timer_stop (m->tmp_loop, &m->timeout_w);
+        wait_time = ev_now (m->tmp_loop) - t0;
+
+        /* move io watcher back to main loop */
+        ev_io_stop (m->tmp_loop, &m->io_w);
+        if (m->main_loop)
+            ev_io_start (m->main_loop, &m->io_w);
+    }
+    if (result_consume (m, buf, len) < 0) {
+        if (m->timeout)
+            errno = ETIMEDOUT;
+        else
+            errno = EIO;
+        return -1;
+    }
+    if (wait_time > warn_sec)
+        msg ("%s: waited %.1lfs for result '%s'", m->name, wait_time, buf);
+    return 0;
+}
+
+/* Handle EV_READ event on im483i serial port.
+ */
+static void serial_cb (struct ev_loop *loop, ev_io *w, int revents)
+{
+    struct motion *m = (struct motion *)((char *)w
+                        - offsetof (struct motion, io_w));
+    int n;
+
+    if ((revents & EV_READ)) {
+        do {
+            n = read (m->fd, m->inbuf + m->inbuf_len,
+                      sizeof (m->inbuf) - m->inbuf_len - 1);
+            if (n > 0) {
+                m->inbuf_len += n;
+                m->inbuf[m->inbuf_len] = '\0';
+            }
+            else if (n < 0) {
+                if (errno != EWOULDBLOCK && errno != EAGAIN)
+                    err ("%s: read", m->name);
+            }
+        } while (n > 0);
+    }
+}
+
+/* Send string to im483i serial port in its entirety.
+ */
+static int serial_send (int fd, const char *s)
+{
+    int len = strlen (s);
+    int sent = 0;
+    int n;
+
+    while (sent < len) {
+        n = write (fd, s + sent, len - sent);
+        if (n > 0) {
+            sent += n;
+        }
+        else if (n < 0) {
+            if (errno != EWOULDBLOCK && errno != EAGAIN)
+                return -1;
         }
     }
-    rc = 0;
-done:
-    return rc;
+    return sent;
 }
 
-static void mdelay (struct motion *m, int msec)
-{
-    if (m->flags & MOTION_DEBUG)
-        fprintf (stderr, "%s:delay %dms\n", m->name, msec);
-    usleep (1000*msec);
-}
-
-/* Send command + \r, receive back echoed command.
+/* Open/configure the serial port for non-blocking I/O,
+ * hardwiring parameters needed for the im483i.
  */
-static int mcmd (struct motion *m, const char *fmt, ...)
-{
-    va_list ap;
-    int rc = -1;
-    char *cmd = NULL;
-    char buf[max_cmdline];
-
-    va_start (ap, fmt);
-    if (vasprintf (&cmd, fmt, ap) < 0)
-        return -1;
-    va_end (ap);
-    if (mprintf (m, "%s\r", cmd) < 0)
-        goto done;
-    if (!mgets (m, buf, sizeof (buf)))
-        goto done;
-    if (strcmp (buf, cmd) != 0) {
-        errno = EPROTO;
-        goto done;
-    }
-    rc = 0;
-done:
-    if (cmd)
-        free (cmd);
-    return rc;
-}
-
-/* Open/configure the serial port
- */
-static int mopen (const char *devname)
+static int serial_open (const char *devname)
 {
     struct termios tio;
     int fd;
 
-    if ((fd = open (devname, O_RDWR | O_NOCTTY)) < 0)
+    if ((fd = open (devname, O_RDWR | O_NOCTTY | O_NONBLOCK)) < 0)
         return -1;
     memset (&tio, 0, sizeof (tio));
     tio.c_cflag = B9600 | CS8 | CLOCAL | CREAD;
@@ -209,7 +313,7 @@ static int mopen (const char *devname)
     tio.c_oflag = 0;
     tio.c_lflag = 0;
     tio.c_cc[VTIME] = 0; /* no timeout */
-    tio.c_cc[VMIN] = 1;  /* block until 1 char available */
+    tio.c_cc[VMIN] = 1;  /* not ready unless at least one character */
     tcflush (fd, TCIFLUSH);
     if (tcsetattr(fd, TCSANOW, &tio) < 0) {
         close (fd);
@@ -218,224 +322,256 @@ static int mopen (const char *devname)
     return fd;
 }
 
-/* Cold start: send " \r", read 2 banner lines and "#".
- * Warm start: send " \r", read " #".
+/* ^C - software reset
+ * Returns im483i to power-up state.
  */
-static int mhello (struct motion *m, bool *coldstart)
+static int motion_reset (struct motion *m)
 {
-    char buf[max_cmdline];
-    int i;
-    bool warm = false;
+    char buf[80];
 
-    if (mputs (m, " \r") < 0)
+    if (m->flags & MOTION_DEBUG) {
+        fprintf (stderr, "%s>'\\003' + 200ms delay\n", m->name);
+    }
+    if (serial_send (m->fd, "\003") < 0)
         return -1;
-    for (i = 0; i < 3; i++) {
-        if (!mgets (m, buf, sizeof (buf)))
+    usleep (1000*200);                // wait for hardware
+
+    m->busy = false;
+    m->inbuf[0] = '\0';
+    m->inbuf_len = 0;
+
+    if (command_send (m, " ") < 0)
+        return -1;
+    for (;;) {
+        if (result_recv (m, buf, sizeof (buf)) < 0)
             return -1;
-        if (!strcmp (buf, " #")) {
-            warm = true;
+        if (!strcmp (buf, "#"))
             break;
-        }
     }
-    if (coldstart)
-        *coldstart = !warm;
     return 0;
 }
 
-/* Send ctrl-C to reset device, then delay while it comes out of reset.
+/* M - move at fixed velocity
+ * Motion may be terminated by @-soft stop, M0-velocity zero, or ESC-abort.
+ * N.B. motion does not resume automatically after an index command.
  */
-static int mreset (struct motion *m)
-{
-    if (mputs (m, "\003") < 0)
-        return -1;
-    mdelay (m, 200);
-    return 0;
-}
-
-/* Examine configuration parameters (via debug output).
- * Assume two lines are returned (three if encoder option installed).
- */
-static int mexamine (struct motion *m)
-{
-    char buf[max_cmdline];
-    int i;
-
-    if (mprintf (m, "X\r") < 0)
-        return -1;
-    for (i = 0; i < 2; i++) {
-        if (!mgets (m, buf, sizeof (buf)))
-            return -1;
-    }
-    return 0;
-}
-
-
-int motion_set_resolution (struct motion *m, int res)
-{
-    if (res < 0 || res > 8) {
-        errno = EINVAL;
-        return -1;
-    }
-    return mcmd (m, "D%d", res);
-}
-
-int motion_set_mode (struct motion *m, int mode)
-{
-    if (mode != 0 && mode != 1) {
-        errno = EINVAL;
-        return -1;
-    }
-    return mcmd (m, "H%d", mode);
-}
-
-int motion_set_current (struct motion *m, int hold, int run)
-{
-    if (hold < 0 || hold > 100 || run < 0 || run > 100) {
-        errno = EINVAL;
-        return -1;
-    }
-    return mcmd (m, "Y%d %d", hold, run);
-}
-
-int motion_set_acceleration (struct motion *m, int accel, int decel)
-{
-    if (accel < 0 || accel > 255 || decel < 0 || decel > 255) {
-        errno = EINVAL;
-        return -1;
-    }
-    return mcmd (m, "K%d %d", accel, decel);
-}
-
-int motion_set_initial_velocity (struct motion *m, int velocity)
-{
-    if (velocity < 20  || velocity > 20000) {
-        errno = EINVAL;
-        return -1;
-    }
-    return mcmd (m, "I%d", velocity);
-}
-
-int motion_set_final_velocity (struct motion *m, int velocity)
-{
-    if (velocity < 20  || velocity > 20000) {
-        errno = EINVAL;
-        return -1;
-    }
-    return mcmd (m, "V%d", velocity);
-}
-
 int motion_move_constant (struct motion *m, int velocity)
 {
     if (velocity != 0 && (abs (velocity) < 20  || abs (velocity) > 20000)) {
         errno = EINVAL;
         return -1;
     }
-    return mcmd (m, "M%d", velocity);
+    return command_sendf (m, "M%d", velocity);
 }
 
+/* Z - read position (non encoder).
+ */
 int motion_get_position (struct motion *m, double *position)
 {
-    char buf[max_cmdline];
+    char buf[80];
     float pos;
 
-    if (mprintf (m, "Z0\r") < 0)
+    if (command_sendf (m, "Z0") < 0)
         return -1;
-    if (!mgets (m, buf, sizeof (buf)))
+    if (result_recv (m, buf, sizeof (buf)) < 0)
         return -1;
-    if (sscanf (buf, "Z0 %f", &pos) != 1)
+    if (sscanf (buf, "Z0 %f", &pos) != 1) {
+        errno = EPROTO;
         return -1;
+    }
     *position = (double)pos;
     return 0;
 }
 
+/* ^ - read moving status
+ */
+int motion_get_status (struct motion *m, int *status)
+{
+    char buf[80];
+    int s;
+
+    if (command_sendf (m, "^") < 0)
+        return -1;
+    if (result_recv (m, buf, sizeof (buf)) < 0)
+        return -1;
+    if (sscanf (buf, "^ %d", &s) != 1) {
+        errno = EPROTO;
+        return -1;
+    }
+    *status = s;
+    return 0;
+}
+
+/* R - relative index
+ */
 int motion_goto_absolute (struct motion *m, double position)
 {
     if (fabs (position) > 8388607.9) {
         errno = EINVAL;
         return -1;
     }
-    return mcmd (m, "R%+.2f", position);
-}
-
-int motion_get_status (struct motion *m, uint8_t *status)
-{
-    char buf[max_cmdline];
-    int s;
-
-    if (mprintf (m, "^\r") < 0)
+    if (command_sendf (m, "R%+.2f", position) < 0)
         return -1;
-    if (!mgets (m, buf, sizeof (buf)))
-        return -1;
-    if (sscanf (buf, "^ %d", &s) != 1)
-        return -1;
-    *status  = s;
+    ev_timer_set (&m->status_poll_w, status_poll_sec, status_poll_sec);
+    ev_timer_start (m->main_loop, &m->status_poll_w);
     return 0;
 }
 
+/* +/- - index
+ */
 int motion_goto_relative (struct motion *m, double offset)
 {
     if (fabs (offset) < 0.01 || fabs (offset) > 8388607.99) {
         errno = EINVAL;
         return -1;
     }
-    return mcmd (m, "%+.2f", offset);
+    if (command_sendf (m, "%+.2f", offset) < 0)
+        return -1;
+    ev_timer_set (&m->status_poll_w, status_poll_sec, status_poll_sec);
+    ev_timer_start (m->main_loop, &m->status_poll_w);
+    return 0;
 }
 
+/* O - set origin
+ */
 int motion_set_origin (struct motion *m)
 {
-    return mcmd (m, "O");
+    return command_send (m, "O");
 }
 
+/* @ - soft stop
+ */
 int motion_soft_stop (struct motion *m)
 {
-    return mcmd (m, "@");
+    return command_send (m, "@");
 }
 
+/* ESC - abort
+ */
+int motion_abort (struct motion *m)
+{
+    m->busy = false; // don't wait for command result
+    return command_send (m, "\033");
+}
+
+/* A - port write
+ */
 int motion_set_io (struct motion *m, uint8_t val)
 {
-    return mcmd (m, "A%d", val);
+    return command_sendf (m, "A%d", val);
 }
 
+/* A - port read
+ */
 int motion_get_io (struct motion *m, uint8_t *val)
 {
-    char buf[max_cmdline];
-    int v;
+    char buf[80];
+    int value;
 
-    if (mprintf (m, "A129\r") < 0)
+    if (command_send (m, "A129") < 0)
         return -1;
-    if (!mgets (m, buf, sizeof (buf)))
+    if (result_recv (m, buf, sizeof (buf)) < 0)
         return -1;
-    if (sscanf (buf, "A129 %d", &v) != 1)
+    if (sscanf (buf, "A129 %d", &value) != 1) {
+        errno = EPROTO;
         return -1;
-    *val = v;
+    }
+    *val = (uint8_t)value;
     return 0;
 }
 
-int motion_init (struct motion *m, const char *devname, int flags,
-                 bool *coldstart)
+/* Poll for moving status change during a goto.
+ * FIXME: estimate of time needed for goto could reduce polling overhead.
+ */
+static void status_poll_cb (struct ev_loop *loop, ev_timer *w, int revents)
 {
-    if (m->fd != -1) {
-        errno = EINVAL;
-        goto error;
+    struct motion *m = (struct motion *)((char *)w
+                        - offsetof (struct motion, status_poll_w));
+    int status;
+
+    if (motion_get_status (m, &status) < 0) {
+        err ("motion_get_status");
+        return;
     }
-    if ((m->fd = mopen (devname)) < 0)
-        goto error;
-    m->flags = flags;
-    if ((m->flags & MOTION_RESET)) {
-        if (mreset (m) < 0)
-            goto error;
+    if (!(status & MOTION_STATUS_MOVING)) {
+        ev_timer_stop (loop, w);
+        if (m->cb)
+            m->cb (m, m->cb_arg);
     }
-    if (mhello (m, coldstart) < 0)
+}
+
+static int motion_configure (struct motion *m, struct motion_config *cfg)
+{
+    if (cfg->resolution < 0 || cfg->resolution > 8)
+        goto inval;
+    if (command_sendf (m, "D%d", cfg->resolution) < 0)
         goto error;
-    if (m->flags & MOTION_DEBUG) {
-        if (mexamine (m) < 0)
-            goto error;
-    }
-    if (mping (m, 2) < 0)
+    if (cfg->mode != 0 && cfg->mode != 1)
+        goto inval;
+    if (command_sendf (m, "H%d", cfg->mode) < 0)
+        goto error;
+    if (cfg->ihold < 0 || cfg->ihold > 100
+                    || cfg->irun < 0 || cfg->irun > 100)
+        goto inval;
+    if (command_sendf (m, "Y%d %d", cfg->ihold, cfg->irun) < 0)
+        goto error;
+    if (cfg->accel < 0 || cfg->accel > 255
+                    || cfg->decel < 0 || cfg->decel > 255)
+        goto inval;
+    if (command_sendf (m, "K%d %d", cfg->accel, cfg->decel) < 0)
+        goto error;
+    if (cfg->initv < 20  || cfg->initv > 20000)
+        goto inval;
+    if (command_sendf (m, "I%d", cfg->initv) < 0)
+        goto error;
+    if (cfg->finalv < 20  || cfg->finalv > 20000)
+        goto inval;
+    if (command_sendf (m, "V%d", cfg->finalv) < 0)
         goto error;
     return 0;
+inval:
+    errno = EINVAL;
 error:
     return -1;
+}
+
+int motion_init (struct motion *m, const char *devname,
+                 struct motion_config *cfg, int flags)
+{
+    if ((m->fd = serial_open (devname)) < 0)
+        goto error;
+    ev_io_init (&m->io_w, serial_cb, m->fd, EV_READ);
+    ev_timer_init (&m->status_poll_w, status_poll_cb, 0., 0.);
+    ev_timer_init (&m->timeout_w, timeout_cb, 0., 0.);
+    m->flags = flags;
+    if (motion_reset (m) < 0)
+        goto error;
+    if (cfg) {
+        if (motion_configure (m, cfg) < 0)
+            goto error;
+    }
+    return 0;
+error:
+    if (m->fd >= 0) {
+        int saved_errno = errno;
+        (void)close (m->fd);
+        m->fd = -1;
+        errno = saved_errno;
+    }
+    return -1;
+}
+
+void motion_start (struct ev_loop *loop, struct motion *m)
+{
+    ev_io_start (loop, &m->io_w);
+    m->main_loop = loop;
+}
+
+void motion_stop (struct ev_loop *loop, struct motion *m)
+{
+    ev_io_stop (loop, &m->io_w);
+    ev_timer_stop (loop, &m->status_poll_w);
+    m->main_loop = NULL;
 }
 
 const char *motion_get_name (struct motion *m)
@@ -443,9 +579,17 @@ const char *motion_get_name (struct motion *m)
     return m->name;
 }
 
+void motion_set_cb (struct motion *m, motion_cb_f cb, void *arg)
+{
+    m->cb = cb;
+    m->cb_arg = arg;
+}
+
 void motion_destroy (struct motion *m)
 {
     if (m) {
+        if (m->tmp_loop)
+            ev_loop_destroy (m->tmp_loop);
         if (m->fd >= 0)
             (void)close (m->fd);
         free (m->name);
@@ -460,6 +604,8 @@ struct motion *motion_new (const char *name)
         goto error;
     m->fd = -1;
     if (!(m->name = strdup (name)))
+        goto error;
+    if (!(m->tmp_loop = ev_loop_new (EVFLAG_AUTO)))
         goto error;
     return m;
 error:

--- a/src/motion.h
+++ b/src/motion.h
@@ -69,7 +69,7 @@ int motion_goto_relative (struct motion *m, double offset);
 
 /* Execute a "soft stop" (with deceleration) on all motion.
  */
-int motion_stop (struct motion *m);
+int motion_soft_stop (struct motion *m);
 
 /* Read moving status.
  */

--- a/src/motion.h
+++ b/src/motion.h
@@ -2,9 +2,10 @@
 
 enum {
     MOTION_DEBUG = 0x01,    /* send telemetry to stderr */
-    MOTION_RESET = 0x02,    /* perform factory reset */
 };
 
+/* Bits for motion_set_io(), motion_get_io() mask.
+ */
 enum {
     MOTION_IO_INPUT1    = 0x01,
     MOTION_IO_INPUT2    = 0x02,
@@ -14,42 +15,31 @@ enum {
     MOTION_IO_OUTPUT3   = 0x20, // ^blue_led
 };
 
+/* Bits for motion_get_status() mask.
+ */
 enum {
-    MOTION_STATUS_MOVING    = 0x01,
-    MOTION_STATUS_TRACKING  = 0x02,
-    MOTION_STATUS_HOMING    = 0x08,
-    MOTION_STATUS_HUNTING   = 0x10,
-    MOTION_STATUS_RAMPING   = 0x20,
+    MOTION_STATUS_MOVING    = 0x01, // axis moving
+    MOTION_STATUS_CONSTANT  = 0x02, // constant velocity
+    MOTION_STATUS_HOMING    = 0x08, // homing routine is active
+    MOTION_STATUS_HUNTING   = 0x10, // encoder correction
+    MOTION_STATUS_RAMPING   = 0x20, // ramping up or down
 };
 
+struct motion_config {
+    int resolution;     // microstep resolution (0:8)
+    int ihold;          // hold current in pct of max (0-100)
+    int irun;           // hold current in pct of max (0-100)
+    int accel;          // acceleration slope (0-255)
+    int decel;          // deceleration slope (0-255)
+    int mode;           // resolution mode (0=fixed, 1=auto)
+    int initv;          // initial velocity for ramp up (20:20000)
+                        //   in full steps/s (auto), or pulses/s (fixed)
+    int finalv;         // final velocity for ramp up (20:20000)
+};                      //   in full steps/s (auto), or pulses/s (fixed)
+
 struct motion;
+typedef void (*motion_cb_f)(struct motion *m, void *arg);
 
-/* Set microstep resolution (0:8)
- */
-int motion_set_resolution (struct motion *m, int resolution);
-
-/* Set hold/run current limit in pct of max (0-100)
- */
-int motion_set_current (struct motion *m, int hold, int run);
-
-/* Set acceleration/deceleration slope (0-255)
- */
-int motion_set_acceleration (struct motion *m, int accel, int decel);
-
-/* Set resolution mode
- * 0=fixed, 1=auto
- */
-int motion_set_mode (struct motion *m, int mode);
-
-/* Set initial velocity for ramp-up, 20:20000
- * In full steps per sec (auto mode), or pulses per sec (fixed mode).
- */
-int motion_set_initial_velocity (struct motion *m, int velocity);
-
-/* Set fnial velocity for ramp-up, 20:20000
- * In full steps per sec (auto mode), or pulses per sec (fixed mode).
- */
-int motion_set_final_velocity (struct motion *m, int velocity);
 
 /* Move at fixed velocity, 0, +-20:20000 (+ = CW, - = CCW)
  * with ramp up or ramp down.
@@ -71,9 +61,13 @@ int motion_goto_relative (struct motion *m, double offset);
  */
 int motion_soft_stop (struct motion *m);
 
+/* Abort motion without deceleration.
+ */
+int motion_abort (struct motion *m);
+
 /* Read moving status.
  */
-int motion_get_status (struct motion *m, uint8_t *status);
+int motion_get_status (struct motion *m, int *status);
 
 /* Set internal position counter to zero.
  */
@@ -88,13 +82,24 @@ int motion_set_io (struct motion *m, uint8_t val);
  */
 const char *motion_get_name (struct motion *m);
 
-/* Initialization
+/* Set callback to be called when a goto has completed.
  */
-int motion_init (struct motion *m, const char *device, int flags,
-                 bool *coldstart);
+void motion_set_cb (struct motion *m, motion_cb_f cb, void *arg);
+
+/* Initialization
+ * Performs a reset, equivalent to the power-up condition (zeroes origin).
+ * Configure from motion_config struct, or if NULL, use nvram settings.
+ */
+int motion_init (struct motion *m, const char *device,
+                 struct motion_config *cfg, int flags);
 
 struct motion *motion_new (const char *name);
 void motion_destroy (struct motion *m);
+
+/* Start/stop watchers.
+ */
+void motion_start (struct ev_loop *loop, struct motion *m);
+void motion_stop (struct ev_loop *loop, struct motion *m);
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/motion.h
+++ b/src/motion.h
@@ -60,14 +60,12 @@ int motion_set_velocity (struct motion *m, int velocity);
  */
 int motion_get_position (struct motion *m, double *position);
 
-/* Slew to position relative to origin.
+/* Slew the to absolute or relative position.  position/offset is in full
+ * steps, with a resolution of 0.01 step.  Motor will ramp up and ramp down
+ * automatically.
  */
-int motion_set_position (struct motion *m, double position);
-
-/* Slew the to current position + offset.  Offset is in full steps, with
- * a resolution of 0.01 step.  Motor will ramp up and ramp down automatically.
- */
-int motion_set_index (struct motion *m, double offset);
+int motion_goto_absolute (struct motion *m, double position);
+int motion_goto_relative (struct motion *m, double offset);
 
 /* Execute a "soft stop" (with deceleration) on all motion.
  */

--- a/src/motion.h
+++ b/src/motion.h
@@ -7,17 +7,6 @@ enum {
 
 struct motion;
 
-/* Initialize communications with indexer on 'devname'.
- */
-struct motion *motion_init (const char *devname, const char *name, int flags,
-                            bool *coldstart);
-
-/* Disconnect from indexer, stopping motion if any.
- */
-void motion_fini (struct motion *m);
-
-const char *motion_name (struct motion *m);
-
 /* Set microstep resolution (0:8)
  */
 int motion_set_resolution (struct motion *m, int resolution);
@@ -96,6 +85,18 @@ int motion_get_port (struct motion *m, uint8_t *val);
 /* Write 6-bit GPIO port.
  */
 int motion_set_port (struct motion *m, uint8_t val);
+
+/* Get name associated with motion axis at creation.
+ */
+const char *motion_get_name (struct motion *m);
+
+/* Initialization
+ */
+int motion_init (struct motion *m, const char *device, int flags,
+                 bool *coldstart);
+
+struct motion *motion_new (const char *name);
+void motion_destroy (struct motion *m);
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/motion.h
+++ b/src/motion.h
@@ -54,7 +54,7 @@ int motion_set_final_velocity (struct motion *m, int velocity);
 /* Move at fixed velocity, 0, +-20:20000 (+ = CW, - = CCW)
  * with ramp up or ramp down.
  */
-int motion_set_velocity (struct motion *m, int velocity);
+int motion_move_constant (struct motion *m, int velocity);
 
 /* Query current position.
  */

--- a/src/motion.h
+++ b/src/motion.h
@@ -14,6 +14,14 @@ enum {
     MOTION_IO_OUTPUT3   = 0x20, // ^blue_led
 };
 
+enum {
+    MOTION_STATUS_MOVING    = 0x01,
+    MOTION_STATUS_TRACKING  = 0x02,
+    MOTION_STATUS_HOMING    = 0x08,
+    MOTION_STATUS_HUNTING   = 0x10,
+    MOTION_STATUS_RAMPING   = 0x20,
+};
+
 struct motion;
 
 /* Set microstep resolution (0:8)
@@ -67,11 +75,6 @@ int motion_stop (struct motion *m);
 
 /* Read moving status.
  */
-#define MOTION_STATUS_MOVING    0x01
-#define MOTION_STATUS_TRACKING  0x02
-#define MOTION_STATUS_HOMING    0x08
-#define MOTION_STATUS_HUNTING   0x10
-#define MOTION_STATUS_RAMPING   0x20
 int motion_get_status (struct motion *m, uint8_t *status);
 
 /* Set internal position counter to zero.

--- a/src/motion.h
+++ b/src/motion.h
@@ -5,6 +5,15 @@ enum {
     MOTION_RESET = 0x02,    /* perform factory reset */
 };
 
+enum {
+    MOTION_IO_INPUT1    = 0x01,
+    MOTION_IO_INPUT2    = 0x02,
+    MOTION_IO_INPUT3    = 0x04,
+    MOTION_IO_OUTPUT1   = 0x08, // ^green_led on daughter board
+    MOTION_IO_OUTPUT2   = 0x10, // ^white_led
+    MOTION_IO_OUTPUT3   = 0x20, // ^blue_led
+};
+
 struct motion;
 
 /* Set microstep resolution (0:8)
@@ -69,22 +78,10 @@ int motion_get_status (struct motion *m, uint8_t *status);
  */
 int motion_set_origin (struct motion *m);
 
-/* Read 6-bit GPIO port.  Bits are:
- *  0 in-1
- *  1 in-2
- *  2 in-3
- *  3 out-1   (green LED: 0=on, 1=off)
- *  4 out-2   (white LED: 0=on, 1=off)
- *  5 out-3   (blue LED: 0=on, 1=off)
+/* Read/write io port
  */
-#define GREEN_LED_MASK  (1<<3)
-#define WHITE_LED_MASK  (1<<4)
-#define BLUE_LED_MASK  (1<<5)
-int motion_get_port (struct motion *m, uint8_t *val);
-
-/* Write 6-bit GPIO port.
- */
-int motion_set_port (struct motion *m, uint8_t val);
+int motion_get_io (struct motion *m, uint8_t *val);
+int motion_set_io (struct motion *m, uint8_t val);
 
 /* Get name associated with motion axis at creation.
  */


### PR DESCRIPTION
This is a rewrite of the motion module, so it can be managed through the ev_loop reactor.

There are still a lot of things that are done synchronously, such as querying for position, or waiting for the previous command to complete.  However, the code is common for synchronous and asynchronous modes, and we now have timeouts and warnings for synchronous operations that take long.

The Stop (:Q#) command in Lx200 is now wired to a callback that sends a stop command to the motion controllers, and can abort a goto.

We poll moving status during a goto so we can detect when it's done and make a callback that restarts tracking in RA.

In general, this should be much more reliable and responsive than before.