### PR TITLE
improve motion efficiency, fix bugs

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -345,6 +345,7 @@ void hpad_cb (struct hpad *h, void *arg)
     /* M1 - emergency stop
      */
     if ((ctrl & HPAD_CONTROL_M1)) {
+        msg ("emergency stop");
         if (motion_abort (ctx->t) < 0) {
             err ("t: motion_abort");
             if (motion_abort (ctx->t) < 0) // one retry

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -273,7 +273,7 @@ double lookup_rate (struct config_axis *axis, int rate,
     if (neg)
         dps *= -1.;
     if (track)
-        dps -= axis->sidereal;
+        dps += axis->sidereal;
     return dps;
 }
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -143,6 +143,7 @@ int main (int argc, char *argv[])
                 break;
             case 'w':   /* --west */
                 ctx.west = true;
+                lx200_flags |= LX200_POINT_WEST; // hint for unaligned starting
                 break;
             case 'h':   /* --help */
             default:

--- a/src/lx200.c
+++ b/src/lx200.c
@@ -486,6 +486,7 @@ void lx200_set_stop_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg)
 int lx200_init (struct lx200 *lx, int port, int flags)
 {
     struct sockaddr_in addr;
+    int point_flags = 0;
 
     lx->flags = flags;
 
@@ -507,7 +508,10 @@ int lx200_init (struct lx200 *lx, int port, int flags)
         msg ("listening on port %d", port);
 
     if ((lx->flags & LX200_DEBUG))
-        point_set_flags (lx->point, POINT_DEBUG);
+        point_flags |= POINT_DEBUG;
+    if ((lx->flags & LX200_POINT_WEST))
+        point_flags |= POINT_WEST;
+    point_set_flags (lx->point, point_flags);
 
     return 0;
 }

--- a/src/lx200.c
+++ b/src/lx200.c
@@ -235,7 +235,7 @@ static int process_command (struct client *c, const char *cmd)
             rc = write_all (c, "1", 1);
         }
         else if (sscanf (cmd + 3, "%d:%d.%d#", &hr, &min, &tenths) == 2) {
-            point_set_target_dec (c->lx->point, hr, min, 6*tenths);
+            point_set_target_ra (c->lx->point, hr, min, 6*tenths);
             rc = write_all (c, "1", 1);
         }
         else

--- a/src/lx200.c
+++ b/src/lx200.c
@@ -154,7 +154,16 @@ static int process_command (struct client *c, const char *cmd)
     /* :SGsHH.H# - Set num hours added to local time to yield UTC
      */
     else if (!strncmp (cmd, ":SG", 3)) {
-        rc = write_all (c, "1", 1);
+        double offset;
+        if (sscanf (cmd + 3, "%lf#", &offset) == 1) {
+            unsigned short neg = 0;
+            if (offset > 0)
+                neg = 1;
+            point_set_longitude_neg (c->lx->point, neg);
+            rc = write_all (c, "1", 1);
+        }
+        else
+            rc = write_all (c, "0", 1);
     }
     /* :SLHH:MM:SS# - Set the local time
      */

--- a/src/lx200.h
+++ b/src/lx200.h
@@ -18,7 +18,8 @@ int lx200_init (struct lx200 *lx, int port, int flags);
 /* Register callback that is triggered when the protocol needs
  * a position update.  Callback should call lx200_set_position().
  */
-void lx200_set_position_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
+void lx200_set_position_ha_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
+void lx200_set_position_dec_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
 
 /* Register callback that is triggered when slew (virtual) buttons
  * are pressed or released.  Callback should call lx200_get_slew()
@@ -38,9 +39,12 @@ void lx200_set_stop_cb  (struct lx200 *lx, lx200_cb_f cb, void *arg);
 
 /* Set t,d position in degrees.
  */
-void lx200_set_position (struct lx200 *lx, double t, double d);
+void lx200_set_position_ha (struct lx200 *lx, double t);
+void lx200_set_position_dec (struct lx200 *lx, double d);
+
 int lx200_get_slew_direction (struct lx200 *lx);
 int lx200_get_slew_rate  (struct lx200 *lx);
+
 void lx200_get_target (struct lx200 *lx, double *t, double *d);
 
 void lx200_start (struct ev_loop *loop, struct lx200 *lx);

--- a/src/lx200.h
+++ b/src/lx200.h
@@ -5,6 +5,7 @@
 
 enum {
     LX200_DEBUG = 1,
+    LX200_POINT_WEST = 2,
 };
 
 struct lx200;

--- a/src/motion.c
+++ b/src/motion.c
@@ -63,6 +63,9 @@
 #include "log.h"
 #include "motion.h"
 
+#define MAX_CMD     80
+#define MAX_BUF     1024
+
 
 struct motion {
     int fd;
@@ -74,7 +77,7 @@ struct motion {
     bool timeout;
     struct ev_loop *main_loop;
     struct ev_loop *tmp_loop;
-    char inbuf[1024];
+    char inbuf[MAX_BUF];
     int inbuf_len;
     bool busy;
     motion_cb_f cb;
@@ -123,7 +126,7 @@ static char *toliteral (const char *s)
  */
 static int command_send (struct motion *m, const char *s)
 {
-    char buf[80];
+    char buf[MAX_CMD];
 
     if (m->busy) {
         if (result_recv (m, NULL, 0) < 0)
@@ -327,7 +330,7 @@ static int serial_open (const char *devname)
  */
 static int motion_reset (struct motion *m)
 {
-    char buf[80];
+    char buf[MAX_CMD];
 
     if (m->flags & MOTION_DEBUG) {
         fprintf (stderr, "%s>'\\003' + 200ms delay\n", m->name);
@@ -370,7 +373,7 @@ int motion_move_constant (struct motion *m, int sps)
  */
 int motion_get_position (struct motion *m, double *position)
 {
-    char buf[80];
+    char buf[MAX_CMD];
     double pos;
 
     if (command_sendf (m, "Z0") < 0)
@@ -389,7 +392,7 @@ int motion_get_position (struct motion *m, double *position)
  */
 int motion_get_status (struct motion *m, int *status)
 {
-    char buf[80];
+    char buf[MAX_CMD];
     int s;
 
     if (command_sendf (m, "^") < 0)
@@ -471,7 +474,7 @@ int motion_set_io (struct motion *m, uint8_t val)
  */
 int motion_get_io (struct motion *m, uint8_t *val)
 {
-    char buf[80];
+    char buf[MAX_CMD];
     int value;
 
     if (command_send (m, "A129") < 0)

--- a/src/motion.c
+++ b/src/motion.c
@@ -175,7 +175,6 @@ static int result_consume (struct motion *m, char *buf, int len)
 
     if (!(p = strstr (m->inbuf, "\r\n")))
         return -1;
-    assert (p != NULL);
     *p = '\0';
 
     if ((m->flags & MOTION_DEBUG)) {

--- a/src/motion.c
+++ b/src/motion.c
@@ -459,8 +459,16 @@ int motion_soft_stop (struct motion *m)
  */
 int motion_abort (struct motion *m)
 {
-    m->busy = false; // don't wait for command result
-    return command_send (m, "\033");
+    char buf[MAX_CMD];
+
+    m->busy = false; // don't wait for previous command result
+    if (command_send (m, "\033") < 0)
+        return -1;
+    do {
+        if (result_recv (m, buf, sizeof (buf)) < 0)
+            return -1;
+    } while (strcmp (buf, "#") != 0);
+    return 0;
 }
 
 /* A - port write

--- a/src/motion.c
+++ b/src/motion.c
@@ -66,6 +66,9 @@
 #define MAX_CMD     80
 #define MAX_BUF     1024
 
+enum {
+    SEND_EXPECT_ECHO = 1,
+};
 
 struct motion {
     int fd;
@@ -124,7 +127,7 @@ static char *toliteral (const char *s)
 /* If busy, wait for result, then clear result buffer.
  * Send string to serial port with \r terminator, then set busy flag.
  */
-static int command_send (struct motion *m, const char *s)
+static int command_send (struct motion *m, int flags, const char *s)
 {
     char buf[MAX_CMD];
 
@@ -148,12 +151,22 @@ static int command_send (struct motion *m, const char *s)
 
     m->busy = true;
 
+    if ((flags & SEND_EXPECT_ECHO)) {
+        char result[MAX_CMD];
+        if (result_recv (m, result, sizeof (result)) < 0)
+            return -1;
+        if (strncmp (buf, result, strlen (result)) != 0) { // ignore \r in buf
+            errno = EPROTO;
+            return -1;
+        }
+    }
+
     return 0;
 }
 
 /* printf-style wrapper for command_send().
  */
-static int command_sendf (struct motion *m, const char *fmt, ...)
+static int command_sendf (struct motion *m, bool flags, const char *fmt, ...)
 {
     va_list ap;
     char *s = NULL;
@@ -164,7 +177,7 @@ static int command_sendf (struct motion *m, const char *fmt, ...)
     va_end (ap);
     if (rc < 0)
         goto done;
-    rc = command_send (m, s);
+    rc = command_send (m, flags, s);
 done:
     free (s);
     return rc;
@@ -343,7 +356,7 @@ static int motion_reset (struct motion *m)
     m->inbuf[0] = '\0';
     m->inbuf_len = 0;
 
-    if (command_send (m, " ") < 0)
+    if (command_send (m, 0, " ") < 0)
         return -1;
     for (;;) {
         if (result_recv (m, buf, sizeof (buf)) < 0)
@@ -366,7 +379,7 @@ int motion_move_constant (struct motion *m, int sps)
         errno = EINVAL;
         return -1;
     }
-    return command_sendf (m, "M%d", sps);
+    return command_sendf (m, SEND_EXPECT_ECHO, "M%d", sps);
 }
 
 /* Z - read position (non encoder).
@@ -376,7 +389,7 @@ int motion_get_position (struct motion *m, double *position)
     char buf[MAX_CMD];
     double pos;
 
-    if (command_sendf (m, "Z0") < 0)
+    if (command_sendf (m, 0, "Z0") < 0)
         return -1;
     if (result_recv (m, buf, sizeof (buf)) < 0)
         return -1;
@@ -395,7 +408,7 @@ int motion_get_status (struct motion *m, int *status)
     char buf[MAX_CMD];
     int s;
 
-    if (command_sendf (m, "^") < 0)
+    if (command_sendf (m, 0, "^") < 0)
         return -1;
     if (result_recv (m, buf, sizeof (buf)) < 0)
         return -1;
@@ -417,7 +430,7 @@ int motion_goto_absolute (struct motion *m, double position)
         errno = EINVAL;
         return -1;
     }
-    if (command_sendf (m, "R%+.2f", position) < 0)
+    if (command_sendf (m, SEND_EXPECT_ECHO, "R%+.2f", position) < 0)
         return -1;
     ev_timer_set (&m->status_poll_w, status_poll_sec, status_poll_sec);
     ev_timer_start (m->main_loop, &m->status_poll_w);
@@ -434,7 +447,7 @@ int motion_goto_relative (struct motion *m, double offset)
         errno = EINVAL;
         return -1;
     }
-    if (command_sendf (m, "%+.2f", offset) < 0)
+    if (command_sendf (m, SEND_EXPECT_ECHO, "%+.2f", offset) < 0)
         return -1;
     ev_timer_set (&m->status_poll_w, status_poll_sec, status_poll_sec);
     ev_timer_start (m->main_loop, &m->status_poll_w);
@@ -445,14 +458,14 @@ int motion_goto_relative (struct motion *m, double offset)
  */
 int motion_set_origin (struct motion *m)
 {
-    return command_send (m, "O");
+    return command_send (m, SEND_EXPECT_ECHO, "O");
 }
 
 /* @ - soft stop
  */
 int motion_soft_stop (struct motion *m)
 {
-    return command_send (m, "@");
+    return command_send (m, SEND_EXPECT_ECHO, "@");
 }
 
 /* ESC - abort
@@ -462,7 +475,7 @@ int motion_abort (struct motion *m)
     char buf[MAX_CMD];
 
     m->busy = false; // don't wait for previous command result
-    if (command_send (m, "\033") < 0)
+    if (command_send (m, 0, "\033") < 0)
         return -1;
     do {
         if (result_recv (m, buf, sizeof (buf)) < 0)
@@ -475,7 +488,7 @@ int motion_abort (struct motion *m)
  */
 int motion_set_io (struct motion *m, uint8_t val)
 {
-    return command_sendf (m, "A%d", val);
+    return command_sendf (m, SEND_EXPECT_ECHO, "A%d", val);
 }
 
 /* A - port read
@@ -485,7 +498,7 @@ int motion_get_io (struct motion *m, uint8_t *val)
     char buf[MAX_CMD];
     int value;
 
-    if (command_send (m, "A129") < 0)
+    if (command_send (m, 0, "A129") < 0)
         return -1;
     if (result_recv (m, buf, sizeof (buf)) < 0)
         return -1;
@@ -534,29 +547,31 @@ static int motion_configure (struct motion *m, struct motion_config *cfg)
 {
     if (cfg->resolution < 0 || cfg->resolution > 8)
         goto inval;
-    if (command_sendf (m, "D%d", cfg->resolution) < 0)
+    if (command_sendf (m, SEND_EXPECT_ECHO, "D%d", cfg->resolution) < 0)
         goto error;
     if (cfg->mode != 0 && cfg->mode != 1)
         goto inval;
-    if (command_sendf (m, "H%d", cfg->mode) < 0)
+    if (command_sendf (m, SEND_EXPECT_ECHO, "H%d", cfg->mode) < 0)
         goto error;
     if (cfg->ihold < 0 || cfg->ihold > 100
                     || cfg->irun < 0 || cfg->irun > 100)
         goto inval;
-    if (command_sendf (m, "Y%d %d", cfg->ihold, cfg->irun) < 0)
+    if (command_sendf (m, SEND_EXPECT_ECHO, "Y%d %d",
+                                                cfg->ihold, cfg->irun) < 0)
         goto error;
     if (cfg->accel < 0 || cfg->accel > 255
                     || cfg->decel < 0 || cfg->decel > 255)
         goto inval;
-    if (command_sendf (m, "K%d %d", cfg->accel, cfg->decel) < 0)
+    if (command_sendf (m, SEND_EXPECT_ECHO, "K%d %d",
+                                                cfg->accel, cfg->decel) < 0)
         goto error;
     if (cfg->initv < 20  || cfg->initv > 20000)
         goto inval;
-    if (command_sendf (m, "I%d", cfg->initv) < 0)
+    if (command_sendf (m, SEND_EXPECT_ECHO, "I%d", cfg->initv) < 0)
         goto error;
     if (cfg->finalv < 20  || cfg->finalv > 20000)
         goto inval;
-    if (command_sendf (m, "V%d", cfg->finalv) < 0)
+    if (command_sendf (m, SEND_EXPECT_ECHO, "V%d", cfg->finalv) < 0)
         goto error;
     if (cfg->steps < 300 || cfg->steps > 8388607)
         goto inval;

--- a/src/motion.c
+++ b/src/motion.c
@@ -372,17 +372,17 @@ int motion_move_constant (struct motion *m, int sps)
 int motion_get_position (struct motion *m, double *position)
 {
     char buf[80];
-    float pos;
+    double pos;
 
     if (command_sendf (m, "Z0") < 0)
         return -1;
     if (result_recv (m, buf, sizeof (buf)) < 0)
         return -1;
-    if (sscanf (buf, "Z0 %f", &pos) != 1) {
+    if (sscanf (buf, "Z0 %lf", &pos) != 1) {
         errno = EPROTO;
         return -1;
     }
-    *position = (double)pos * (m->cfg.ccw ? -1 : 1);
+    *position = pos * (m->cfg.ccw ? -1 : 1);
     return 0;
 }
 

--- a/src/point.c
+++ b/src/point.c
@@ -116,14 +116,20 @@ void point_get_target (struct point *p, double *t, double *d)
     *d = dec;
 }
 
-void point_set_position (struct point *p, double t, double d)
+void point_set_position_ha (struct point *p, double t)
 {
     p->posn_raw.ra = t;
+
+    if ((p->flags & POINT_DEBUG))
+        msg ("%s: %.6lf", __FUNCTION__, p->posn_raw.ra);
+}
+
+void point_set_position_dec (struct point *p, double d)
+{
     p->posn_raw.dec = d;
 
     if ((p->flags & POINT_DEBUG))
-        msg ("%s: raw position = (%.6lf, %.6lf)",
-             __FUNCTION__, p->posn_raw.ra, p->posn_raw.dec);
+        msg ("%s: %.6lf", __FUNCTION__, p->posn_raw.dec);
 }
 
 void point_sync_target (struct point *p)

--- a/src/point.c
+++ b/src/point.c
@@ -37,6 +37,8 @@ struct point {
     struct ln_equ_posn      posn_raw; // uncorrected telescope position (deg)
     struct ln_equ_posn      zpc;      // zero point correction (deg)
     struct lnh_equ_posn     target;   // ra,dec of current "target" (deg)
+    int lng_pos_isset:1;
+    int lng_sign_isset:1;
 };
 
 /* Get the apparent local sidereal time, in degrees,
@@ -67,13 +69,27 @@ void point_set_latitude (struct point *p, int deg, int min, double sec)
 
 void point_set_longitude (struct point *p, int deg, int min, double sec)
 {
-    p->observer.lng.neg = (deg < 0);
+    // p->observer.lng.neg
     p->observer.lng.degrees = abs (deg);
     p->observer.lng.minutes = min;
     p->observer.lng.seconds = sec;
+    p->lng_pos_isset = 1;
 
-    if ((p->flags & POINT_DEBUG))
-        msg ("%s: %.6lf", __FUNCTION__, ln_dms_to_deg (&p->observer.lng));
+    if ((p->flags & POINT_DEBUG)) {
+        if (p->lng_sign_isset)
+            msg ("%s: %.6lf", __FUNCTION__, ln_dms_to_deg (&p->observer.lng));
+    }
+}
+
+void point_set_longitude_neg (struct point *p, unsigned short neg)
+{
+    p->observer.lng.neg = neg;
+    p->lng_sign_isset = 1;
+
+    if ((p->flags & POINT_DEBUG)) {
+        if (p->lng_pos_isset)
+            msg ("%s: %.6lf", __FUNCTION__, ln_dms_to_deg (&p->observer.lng));
+    }
 }
 
 void point_set_target_dec (struct point *p, int deg, int min, double sec)

--- a/src/point.c
+++ b/src/point.c
@@ -186,6 +186,11 @@ void point_get_position_dec (struct point *p, int *deg, int *min, double *sec)
 void point_set_flags (struct point *p, int flags)
 {
     p->flags = flags;
+
+    if ((p->flags & POINT_WEST))
+        p->zpc.ra = 90.;    // W horizon (until sync)
+    else
+        p->zpc.ra = -90.;   // E horizon (until sync)
 }
 
 struct point *point_new (void)

--- a/src/point.h
+++ b/src/point.h
@@ -56,7 +56,8 @@ void point_sync_target (struct point *p);
 
 /* Set/update uncorrected telescope position (in degrees).
  */
-void point_set_position (struct point *p, double t, double d);
+void point_set_position_ha (struct point *p, double t);
+void point_set_position_dec (struct point *p, double dec);
 
 /* Get corrected telescope position in (ra,dec).
  * This is computed from uncorrected telescope position, zero point

--- a/src/point.h
+++ b/src/point.h
@@ -32,10 +32,11 @@ void point_destroy (struct point *p);
 void point_set_flags (struct point *p, int flags);
 
 /* Set observer's position (lat,lng)
- * 'deg' may be signed.
+ * Sign is set separately with _neg(), to support a quirk of LX200 protocol
  */
 void point_set_latitude (struct point *p, int deg, int min, double sec);
 void point_set_longitude (struct point *p, int deg, int min, double sec);
+void point_set_longitude_neg (struct point *p, unsigned short neg);
 
 /* Set target object coordinates in (ra,dec).
  * The target object is a "register" used for syncing zero point corrections

--- a/src/point.h
+++ b/src/point.h
@@ -24,6 +24,7 @@ struct point;
 
 enum {
     POINT_DEBUG = 1,
+    POINT_WEST = 2,     // set initial point to western horizon, not eastern
 };
 
 struct point *point_new (void);

--- a/src/test-lx200.c
+++ b/src/test-lx200.c
@@ -42,7 +42,8 @@ static const struct option longopts[] = {
 
 void lx200_goto_cb (struct lx200 *lx, void *arg);
 void lx200_slew_cb (struct lx200 *lx, void *arg);
-void lx200_pos_cb (struct lx200 *lx, void *arg);
+void lx200_pos_ha_cb (struct lx200 *lx, void *arg);
+void lx200_pos_dec_cb (struct lx200 *lx, void *arg);
 
 static void usage (void)
 {
@@ -87,7 +88,8 @@ int main (int argc, char *argv[])
     lx = lx200_new ();
     if (lx200_init (lx, DEFAULT_LX200_PORT, LX200_DEBUG) < 0)
         err_exit ("hpad_init");
-    lx200_set_position_cb (lx, lx200_pos_cb, NULL);
+    lx200_set_position_ha_cb (lx, lx200_pos_ha_cb, NULL);
+    lx200_set_position_dec_cb (lx, lx200_pos_dec_cb, NULL);
     lx200_set_slew_cb (lx, lx200_slew_cb, NULL);
     lx200_set_goto_cb (lx, lx200_goto_cb, NULL);
     lx200_start (loop, lx);
@@ -103,9 +105,14 @@ int main (int argc, char *argv[])
     return 0;
 }
 
-void lx200_pos_cb (struct lx200 *lx, void *arg)
+void lx200_pos_ha_cb (struct lx200 *lx, void *arg)
 {
-    lx200_set_position (lx, 0., 0.);
+    lx200_set_position_ha (lx, 0.);
+}
+
+void lx200_pos_dec_cb (struct lx200 *lx, void *arg)
+{
+    lx200_set_position_dec (lx, 0.);
 }
 
 void lx200_slew_cb (struct lx200 *lx, void *arg)


### PR DESCRIPTION
This PR avoids unnecssary calls to `motion_get_position()` requests by splitting up the lx200 and pointing position callbacks.  it also makes most of the motion commands synchronous (wait for result) rather than fire and forget.

In addition, fix several bugs:  RA tracking velocity flip introduced by last PR, and LST using incorrect longitude due to not implementing one of the LX200 protocol verbs.

Finally, initialize the HA zero point so that the telescope points to the E horizon by default at power-up (western horizon if `--west`.